### PR TITLE
build: enable bevy dynamic linking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "611dd99f412e862610adb43e2243b16436c6d8009f6d9dbe8ce3d6d840b34029"
 dependencies = [
+ "bevy_dylib",
  "bevy_internal",
 ]
 
@@ -539,6 +540,15 @@ dependencies = [
  "bevy_utils",
  "const-fnv1a-hash",
  "sysinfo",
+]
+
+[[package]]
+name = "bevy_dylib"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b3b76f0d7a4da8f944e5316f2d2d2af3bbb40d87508355993ea69afbc9411c"
+dependencies = [
+ "bevy_internal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ opt-level = 3
 
 [profile.release]
 opt-level = "z"
+
+[features]
+# N.b. we may need to disable the default features when building wasm.
+dynamic = ["bevy/dynamic_linking"]
+default = ["dynamic"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Enabling this feature requires the nightly toolchain, so a rust-toolchain file has been added to the repo to ensure the override is in place for the project.

This diff enables the feature by default, but this might break building for wasm. If it does, we can (at time of writing) pass `--no-default-features`, or otherwise we'll just have to change the feature list in the manifest.

For now, it should improve build times while we iterate.