### PR TITLE
Feat: Use custom events for controls instead of directly using keyboard input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,13 @@ struct BackgroundMusic;
 #[derive(Resource)]
 struct SoundFX;
 
+#[derive(Event)]
+pub enum PlayerInputEvent {
+    MoveLeft,
+    MoveRight,
+    Idle,
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, States)]
 enum GameState {
     #[default]
@@ -50,6 +57,7 @@ fn main() {
         .init_state::<GameState>()
         .add_audio_channel::<BackgroundMusic>()
         .add_audio_channel::<SoundFX>()
+        .add_event::<PlayerInputEvent>()
         .add_plugins(
             DefaultPlugins
                 .set(WindowPlugin {
@@ -70,7 +78,7 @@ fn main() {
         ))
         .add_plugins((AnimationPlugin, BoulderPlugin, CameraPlugin, PlayerPlugin))
         // .add_plugins((WorldInspectorPlugin::new(), EditorPlugin::default())) // Egui editors
-        .add_systems(Update, main_menu_button_system)
+        .add_systems(Update, (movement, main_menu_button_system))
         .add_systems(Update, bevy::window::close_on_esc)
         .add_systems(OnEnter(GameState::InGame), (spawn_floor, spawn_walls))
         .add_systems(OnEnter(GameState::MainMenu), (setup_title, setup_main_menu))
@@ -79,6 +87,16 @@ fn main() {
             (cleanup_title, cleanup_main_menu),
         )
         .run();
+}
+
+fn movement(keyboard_input: Res<ButtonInput<KeyCode>>, mut events: EventWriter<PlayerInputEvent>) {
+    if keyboard_input.pressed(KeyCode::ArrowLeft) {
+        events.send(PlayerInputEvent::MoveLeft);
+    } else if keyboard_input.pressed(KeyCode::ArrowRight) {
+        events.send(PlayerInputEvent::MoveRight);
+    } else {
+        events.send(PlayerInputEvent::Idle);
+    }
 }
 
 fn spawn_floor(mut commands: Commands) {


### PR DESCRIPTION
Uses keyboard inputs in `main.rs` to send custom events for movement. The events are picked up in `player.rs` and used to move the player. I tried to use it for moving the camera as well but that wasn't successful.

These custom events seem like they might be handy to us for pushing the boulder and maybe other events/state changes too.