### PR TITLE
Movement priority

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -47,9 +47,9 @@ impl Plugin for PlayerPlugin {
                 (
                     fall,
                     hurt,
-                    movement,
+                    movement.after(fall),
                     rotate,
-                    push_boulder,
+                    push_boulder.after(movement),
                     update_sprite_direction,
                     update_fatigue_marker,
                 )


### PR DESCRIPTION
Set the system order of falling -> moving -> pushing. This order seems to make the most sense and also seems to stop the state fighting that was going on.